### PR TITLE
merge the baidusitemap instead of sitemap from _config

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var pathFn = require('path');
 
 var config = hexo.config.baidusitemap = merge({
   path: 'baidusitemap.xml'
-}, hexo.config.sitemap);
+}, hexo.config.baidusitemap);
 
 if (!pathFn.extname(config.path)){
   config.path += '.xml';


### PR DESCRIPTION
Based on the documentation of `baidu sitemap generator`, it says you can config the `baidusitemap` section in config file so that you can customize the the sitemap file name. 

In fact, the code is merge the `sitemap` instead of `baidusitemap` section from `_config.yml`, which should not be as expected. 
So fix it