### PR TITLE
Support use separate url for baidu sitemap

### DIFF
--- a/baidusitemap.ejs
+++ b/baidusitemap.ejs
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 <%
-  var url = config.url + config.root;
+  var baiduUrl = config.url
+
+  if (config.baidusitemap.url) {
+    baiduUrl = config.baidusitemap.url
+  }
+
+  var url = baiduUrl + config.root;
   posts.forEach(function(post){
   if(post.categories){
 %>  <url>


### PR DESCRIPTION
In some case, there may be mirrred site, we would like baidu sitemap uses different site url with default url.