### PR TITLE
修复标题中带有&符号的问题

### DIFF
--- a/baidusitemap.ejs
+++ b/baidusitemap.ejs
@@ -11,7 +11,7 @@
   posts.forEach(function(post){
   if(post.categories){ -%>
   <url>
-    <loc><%- encodeURI(url + post.path) %></loc>
+    <loc><%- encodeURI(url)+encodeURIComponent(post.path) %></loc>
     <lastmod><%= post.updated.toDate().toISOString().replace(/T.*$/i, "") || post.date.toDate().toISOString().replace(/T.*$/i, "") %></lastmod>
   </url>
 <%}}) -%>


### PR DESCRIPTION
标题中带有' &'、'/' 等符号时，生成的xml会解析错误，导致抓取时提示url提取错误